### PR TITLE
Fix KTH event detail links

### DIFF
--- a/StartSch.Tests/KthBmeHuModuleTests.cs
+++ b/StartSch.Tests/KthBmeHuModuleTests.cs
@@ -1,0 +1,16 @@
+using StartSch.Modules.KthBmeHu;
+
+namespace StartSch.Tests;
+
+[TestClass]
+public sealed class KthBmeHuModuleTests
+{
+    [TestMethod]
+    public void GetEventUrlBuildsEventDetailsUrl()
+    {
+        Assert.AreEqual(
+            "https://www.kth.bme.hu/hallgatoknak/idopontok/550",
+            KthBmeHuModule.GetEventUrl(550)
+        );
+    }
+}

--- a/StartSch/Modules/KthBmeHu/KthBmeHuModule.cs
+++ b/StartSch/Modules/KthBmeHu/KthBmeHuModule.cs
@@ -7,7 +7,10 @@ public class KthBmeHuModule() : IModule
     public const string Url = "https://www.kth.bme.hu";
     public const string RssUrl = Url + "/rss";
     public const string CurrentPostUrlPrefix = Url + "/hirek/aktualis/";
+    public const string CurrentEventUrlPrefix = Url + "/hallgatoknak/idopontok/";
     public const string CalendarEndpoint = Url + "/calendar-ajax/";
+
+    public static string GetEventUrl(int externalId) => CurrentEventUrlPrefix + externalId;
     
     public static void Register(IServiceCollection services)
     {

--- a/StartSch/Modules/KthBmeHu/KthBmeHuPollJob.cs
+++ b/StartSch/Modules/KthBmeHu/KthBmeHuPollJob.cs
@@ -195,7 +195,7 @@ public class KthBmeHuPollJob(
                         );
                         entry ??= new()
                         {
-                            ExternalUrl = KthBmeHuModule.Url,
+                            ExternalUrl = KthBmeHuModule.GetEventUrl(externalId),
                             ExternalIdInt = externalId,
                             Start = hintDate
                                 .AtMidnight()


### PR DESCRIPTION
## Summary

- build scraped KTH event links with the full event-details path instead of the site root
- centralize event URL construction in `KthBmeHuModule`
- add a regression test for the URL generated from event ID `550`

Fixes #207.

## Validation

- `dotnet test .\StartSch.Tests\StartSch.Tests.csproj --filter 'FullyQualifiedName~KthBmeHuModuleTests' --nologo --no-restore` — passed (1/1) with .NET SDK 10.0.300 and Bun 1.3.14; the first attempt stopped at the repository's build step because Bun was not initially installed
- `dotnet test .\StartSch.Tests\StartSch.Tests.csproj --nologo --no-restore` — 16 passed, 4 failed in the unchanged `DateFormatterTests`; on Windows the Hungarian day abbreviations differ from the expected strings (`Cs`/`Sze` instead of `cs.`/`sze.`)
- `dotnet format .\StartSCH.slnx --verify-no-changes --no-restore --include .\StartSch.Tests\KthBmeHuModuleTests.cs` — passed with a workspace-load warning
- multi-file `dotnet format --verify-no-changes` — not clean because the two existing source files use CRLF while the formatter expects LF and contain pre-existing whitespace findings; no broad formatting changes were made
- live calendar endpoint returned `href="550/"`; `https://www.kth.bme.hu/hallgatoknak/idopontok/550` returned HTTP 200
- `git diff --check upstream/main...HEAD` — passed

## Notes

- no dependencies or lockfiles changed
- the change only affects external URLs stored for KTH calendar events
